### PR TITLE
adding predictions loop and endpoints

### DIFF
--- a/caches.py
+++ b/caches.py
@@ -1,0 +1,100 @@
+"""caches module
+
+This module contains functions and classes to help with accessing and upating
+the prediction cache. This cache holds the previously requested prediction
+results.
+"""
+import abc
+import threading as t
+
+import errors
+
+def updater(response_q, storage):
+    """update the cache with predictions
+
+    This function is meant to be used as a thread target. It will listen for
+    responses from the prediction process on the response_q queue. As
+    responses are registered, the storage cache will be updated.
+
+    Arguments:
+    response_q -- A queue of prediction responses
+    storage -- A Cache object for storing predictions
+    """
+    while True:
+        resp = response_q.get()
+        if resp == 'stop':
+            break
+        storage.update(resp)
+
+
+class Cache():
+    """an abstract base for storage caches
+
+    Children of this class need to be thread safe.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def store(self, prediction):
+        """store a new record
+
+        raises PredictionExists if the id is already in the cache
+        """
+        pass
+
+    @abc.abstractmethod
+    def get(self, p_id):
+        """get a record by id
+
+        raises PredictionNotFound if the id is not in the cache
+        """
+        pass
+
+    @abc.abstractmethod
+    def update(self, prediction):
+        """update an existing record
+
+        raises PredictionNotFound if the id is not in the cache
+        """
+        pass
+
+
+class MemoryCache(Cache):
+    """a memory backed cache
+
+    This cache will not retain information on restart, please use it
+    responsibly.
+    """
+    def __init__(self):
+        self.data = {}
+        self.lock = t.Lock()
+
+    def store(self, prediction):
+        exists = False
+        self.lock.acquire()
+        if prediction['id'] not in self.data:
+            self.data[prediction['id']] = prediction
+        else:
+            exists = True
+        self.lock.release()
+        if exists:
+            raise errors.PredictionExists
+
+    def get(self, p_id):
+        self.lock.acquire()
+        ret = self.data.get(p_id)
+        self.lock.release()
+        if ret is None:
+            raise errors.PredictionNotFound
+        return ret
+
+    def update(self, prediction):
+        exists = True
+        self.lock.acquire()
+        if prediction['id'] in self.data:
+            self.data[prediction['id']] = prediction
+        else:
+            exists = False
+        self.lock.release()
+        if not exists:
+            raise errors.PredictionNotFound

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,21 @@
+"""errors module
+
+Contains helpers for generating REST based error response and exception
+classes.
+"""
+from flask import json
+
+
+def single_error_response(status, title, details):
+    err = {'errors': [{'status': status, 'title': title, 'details': details}]}
+    resp = json.jsonify(err)
+    resp.status = status
+    return resp
+
+
+class PredictionExists(Exception):
+    pass
+
+
+class PredictionNotFound(Exception):
+    pass

--- a/predictions.py
+++ b/predictions.py
@@ -1,0 +1,29 @@
+"""predictions module
+
+Predictions contains the functions and classes related to the Apache Spark
+based prediction routines.
+"""
+
+
+def loop(request_q, response_q):
+    """processing loop for predictions
+
+    This function is meant to be used as the main loop for a process, it
+    will wait for new requests on the request_q queue and write responses on
+    the response_q queue.
+    """
+    # just leaving these here for future reference (elmiko)
+    # from pyspark import sql as pysql
+    # spark = pysql.SparkSession.builder.appName("JiminyRec").getOrCreate()
+    # sc = spark.sparkContext
+
+    response_q.put('ready')  # let the main process know we are ready to start
+
+    while True:
+        req = request_q.get()
+        if req == 'stop':
+            break
+        resp = req
+        resp.update(products=
+                    [{'id': p['id'], 'rating': 5.0} for p in req['products']])
+        response_q.put(resp)

--- a/views.py
+++ b/views.py
@@ -1,14 +1,61 @@
+import uuid
+
 from flask import json
+from flask import request as fr
 import flask.views as fv
+
+import errors
 
 
 class ServerInfo(fv.MethodView):
     info = {
         'application': {
-            'name': 'recommender-rest-skeleton',
+            'name': 'jiminy-recommender',
             'version': '0.0.0'
             }
         }
 
     def get(self):
         return json.jsonify(self.info)
+
+
+class Predictions(fv.MethodView):
+    def __init__(self, storage, request_q):
+        self.storage = storage
+        self.request_q = request_q
+
+    def post(self):
+        data = json.loads(fr.data)
+        r_dict = {
+            'user': data['user'],
+            'id': uuid.uuid4().hex,
+            'products': [
+                {'id': p_id, 'rating': 0.0} for p_id in data['products']
+            ]
+        }
+        try:
+            self.storage.store(r_dict)
+            self.request_q.put(r_dict)
+            resp = json.jsonify(prediction=r_dict)
+            resp.status = '201'
+            resp.headers.add('Location',
+                             '/predictions/{}'.format(r_dict['id']))
+        except errors.PredictionExists:
+            resp = errors.single_error_response(
+                '500', 'Server Error',
+                'A prediction with that ID already exists')
+        return resp
+
+
+class PredictionDetail(fv.MethodView):
+    def __init__(self, storage):
+        self.storage = storage
+
+    def get(self, p_id):
+        try:
+            data = self.storage.get(p_id)
+            resp = json.jsonify(data)
+        except errors.PredictionNotFound:
+            resp = errors.single_error_response(
+                '400', 'Not Found', 'That prediction does not exist')
+        return resp


### PR DESCRIPTION
This is a big change that brings in the /predictions endpoint and a
bunch of support stuff for it. The Spark context is stubbed out in the
prediction loop for easy reference later.

The key components of communication are 2 multiprocessing.Queue objects
that can be used to send requests to and response from the prediction
process. There is also a thread which helps synchornize communication
between the 2 processes. Lastly, the cache has threading.Lock's to keep
it safe with the HTTP servicing thread.

Changes
* add a second process to do prediction calculations
* add a url for /predictions to post new requests
* add a url for /predictions/<id> to get details
* add a memory based storage backend for cache
* add errors module with helpers and exceptions
* add an updater thread to keep cache in sync with prediction process